### PR TITLE
Fix linter rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+ - unused_optional_binding
+ - trailing_whitespace


### PR DESCRIPTION
**Disable** the following rules for linter:
1. unused_optional_binding
```
if let _ = varValue?
```
2. trailing_whitespace
```
    print("Do")
    
    print("Do then")
```